### PR TITLE
README incorrectly referenced nonexistent file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ On Command Line:
 }
 ```
 
-6. Configure bundle name in `cypress.config.json`:
+6. Configure bundle name in `cypress.config.ts`:
 ```
 {
   ...


### PR DESCRIPTION
README referenced cypress.config.json, which is supposed to be cypress.config.ts